### PR TITLE
Align headers and license metadata with govern-opensource standard

### DIFF
--- a/FILE-HEADER
+++ b/FILE-HEADER
@@ -1,2 +1,2 @@
-# SPDX-FileCopyrightText: Copyright (c), CloudZero, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
+#  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0

--- a/javascript/eslint.config.mjs
+++ b/javascript/eslint.config.mjs
@@ -1,10 +1,5 @@
-/**
- * Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
- * Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
- * Direct all questions to legal@cloudzero.com
- *
- * CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
- */
+//  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
 
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";

--- a/javascript/jest.config.js
+++ b/javascript/jest.config.js
@@ -1,10 +1,5 @@
-/**
- * Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
- * Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
- * Direct all questions to legal@cloudzero.com
- *
- * CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
- */
+//  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
 
 module.exports = {
   preset: "ts-jest",

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -1,10 +1,5 @@
-/**
- * Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
- * Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
- * Direct all questions to legal@cloudzero.com
- *
- * CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
- */
+//  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
 
 /**
  * CloudZero TypeScript Template Package

--- a/javascript/tests/index.test.ts
+++ b/javascript/tests/index.test.ts
@@ -1,10 +1,5 @@
-/**
- * Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
- * Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
- * Direct all questions to legal@cloudzero.com
- *
- * CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
- */
+//  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
 
 import { greet, VERSION } from "../src/index";
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "CloudZero Open Source Template"
 readme = "README.md"
 requires-python = ">=3.11"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 authors = [
     { name = "CloudZero", email = "support@cloudzero.com" },
 ]
@@ -18,7 +18,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: MacOS",
     "Operating System :: Unix",

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -1,8 +1,5 @@
-# Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
-# Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
-# Direct all questions to legal@cloudzero.com
-#
-# CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
+#  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
 
 """
 CloudZero Python Template Package.

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,7 +1,4 @@
-# Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
-# Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
-# Direct all questions to legal@cloudzero.com
-#
-# CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
+#  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
 
 """Tests for CloudZero Python Template Package."""

--- a/python/tests/test_example.py
+++ b/python/tests/test_example.py
@@ -1,8 +1,5 @@
-# Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL
-# Unauthorized copying of this file and/or project, via any medium is strictly prohibited.
-# Direct all questions to legal@cloudzero.com
-#
-# CHANGELOG: 2025-11-17 - Initial creation (erik.peterson)
+#  SPDX-FileCopyrightText: Copyright (c) CloudZero, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
 
 """Example test file for demonstrating pytest setup."""
 


### PR DESCRIPTION
## What

Brings the OSS template in line with the [govern-opensource standard](https://github.com/Cloudzero/cz-standards/tree/main/govern-opensource), surfaced during the [CTO-1890](https://cloudzero.atlassian.net/browse/CTO-1890) OSS release review:

1. **Replace proprietary headers with SPDX Apache-2.0 headers** in all 7 Python and JS/TS source files. They carried `Copyright (c) CloudZero - ALL RIGHTS RESERVED - PROPRIETARY AND CONFIDENTIAL ... Direct all questions to legal@cloudzero.com` — a proprietary notice that every repo created from this open-source template inherits, contradicting the Apache-2.0 licensing the template exists to establish.
2. **Fix `FILE-HEADER`**: stray comma (`Copyright (c), CloudZero`) that didn't match the standard's header template or its validation regex.
3. **`python/pyproject.toml`**: PEP 639 SPDX string form (`license = "Apache-2.0"`), `setuptools>=77` (required for PEP 639), and removal of the `License ::` classifier (deprecated by PEP 639; newer setuptools rejects it alongside a license expression).

All headers verified against the standard's validation regex. `javascript/package.json` already declared `Apache-2.0` correctly — unchanged. `CHANGELOG.md` deliberately untouched since it's template content shipped to downstream projects.

## Related

- [cz-standards PR #68](https://github.com/Cloudzero/cz-standards/pull/68) — same PEP 639 fix in the standard's own example
- [Open Source at CloudZero (Confluence)](https://cloudzero.atlassian.net/wiki/spaces/ENG/pages/2991030273/Open+Source+at+CloudZero) — regex + example fixed (v30)

PR Generated with AI

Co-Authored-By: AI

[CTO-1890]: https://cloudzero.atlassian.net/browse/CTO-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ